### PR TITLE
Disable xdebug on php8.0 images used in build server [MAILPOET-3412][MAILPOET-3411]

### DIFF
--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -16,3 +16,5 @@ RUN sudo apt-get update && \
   # Clean up
   sudo apt-get clean && \
   sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN sudo sed -i 's/^zend_extension/;zend_extension/g' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini


### PR DESCRIPTION
Circle CI PHP image contains XDebug that slows PHP execution. We don't use Xdebug on CI so I've disabled it on the image level by commenting it in config. It can be re-enabled by using the similar sed command in Circle CI job configuration.

[MAILPOET-3412][MAILPOET-3411]

[MAILPOET-3412]: https://mailpoet.atlassian.net/browse/MAILPOET-3412
[MAILPOET-3411]: https://mailpoet.atlassian.net/browse/MAILPOET-3411