### PR TITLE
Add Dockerfile for PHP-CLI 8.0

### DIFF
--- a/8.0-cli/Dockerfile
+++ b/8.0-cli/Dockerfile
@@ -1,0 +1,23 @@
+FROM php:8.0-cli
+
+RUN apt-get update && \
+    apt-get -y install \
+            git \
+            zlib1g-dev \
+            libpng-dev \
+            libssl-dev \
+            libzip-dev \
+            default-mysql-client \
+            sudo less  \
+            unzip \
+        --no-install-recommends && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    docker-php-ext-install gd bcmath zip mysqli pdo pdo_mysql && \
+    echo "date.timezone = UTC" >> /usr/local/etc/php/php.ini && \
+    curl -sS https://getcomposer.org/installer | php -- \
+        --filename=composer \
+        --install-dir=/usr/local/bin && \
+    curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar && \
+    chmod +x wp-cli.phar && \
+    mv wp-cli.phar /usr/local/bin/wp


### PR DESCRIPTION
Image is published here: https://hub.docker.com/layers/mailpoet/wordpress/8.0-cli_20220126.1/images/sha256-91a672898fc4d5483c9c7e1a558942cfcc216784167039b59dd12439ff00dbb1?context=explore

[MAILPOET-4014]

[MAILPOET-4014]: https://mailpoet.atlassian.net/browse/MAILPOET-4014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ