### PR TITLE
Attempt to fix P2 link shorthand

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ docker build -t "mailpoet/wordpress:wp-5.3_php7.3_20200617.1" wp-5.3/php7.3
 ```
 
 
-Build multiplatform images and push to the docker hub using this command (more details on PcD9cT-ZO):
+Build multiplatform images and push to the docker hub using this command (more details on PcD9cT-ZO-p2):
 ```
 docker buildx build --platform linux/amd64,linux/arm64 -t "mailpoet/wordpress:wp-5.9_php8.1_20220130.1" wp-5.9/php8.1 --push
 ```


### PR DESCRIPTION
The tampermonkey script that we use to expand shorthand P2 links was not working for the shorthand used in the README.md file because it was missing the -p2 suffix. To test: https://github.com/mailpoet/wordpress-images/blob/cf3dd981e6851d53e951adf33f897f1b591aec0c/README.md