### PR TITLE
Add Dockerfile for WP 5.6 PHP 7.2 image [MAILPOET-4225]

### DIFF
--- a/wp-5.6/php7.2/Dockerfile
+++ b/wp-5.6/php7.2/Dockerfile
@@ -1,0 +1,7 @@
+FROM wordpress:5.6-php7.2
+
+RUN docker-php-ext-install pdo_mysql && \
+    echo "date.timezone = UTC" >> /usr/local/etc/php/php.ini && \
+    \
+    # allow .htaccess files (between <Directory /var/www/> and </Directory>, which is WordPress installation)
+    sed -i '/<Directory \/var\/www\/>/,/<\/Directory>/ s/AllowOverride None/AllowOverride All/' /etc/apache2/apache2.conf


### PR DESCRIPTION
This image will be used for the acceptance_oldest CircleCI build job now that WP 5.6 is the minimum WordPress version that MailPoet supports.

[MAILPOET-4225]

[MAILPOET-4225]: https://mailpoet.atlassian.net/browse/MAILPOET-4225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ