### PR TITLE
Use nightly build of WP-CLI in PHP 8.2.0RC6 image [MAILPOET-4876]

### DIFF
--- a/8.2.0RC6-cli/Dockerfile
+++ b/8.2.0RC6-cli/Dockerfile
@@ -22,9 +22,9 @@ RUN apt-get update && \
     curl -sS https://getcomposer.org/installer | php -- \
         --filename=composer \
         --install-dir=/usr/local/bin && \
-    curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar && \
-    chmod +x wp-cli.phar && \
-    mv wp-cli.phar /usr/local/bin/wp && \
+    curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar && \
+    chmod +x wp-cli-nightly.phar && \
+    mv wp-cli-nightly.phar /usr/local/bin/wp && \
     printf "account default\nhost smtp\nport 1025" > /etc/msmtprc && \
     git clone -b "3.2.0RC2" --depth 1 https://github.com/xdebug/xdebug.git /usr/src/php/ext/xdebug \
     && docker-php-ext-configure xdebug --enable-xdebug-dev \


### PR DESCRIPTION
[MAILPOET-4876]

This is to be used temporarily until a new stable WP-CLI version (probably 2.8.0) which fixes PHP 8.2 deprecations is released.

[MAILPOET-4876]: https://mailpoet.atlassian.net/browse/MAILPOET-4876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ