### PR TITLE
Update node in PHP8.1 image to node 19 [MAILPOET-5102]

### DIFF
--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -7,7 +7,7 @@ RUN sudo add-apt-repository ppa:ondrej/php -y && \
   sudo pecl install xdebug &&\
   \
   # Install NodeJS, enable Corepack
-  curl -sL https://deb.nodesource.com/setup_17.x | sudo -E bash - && \
+  curl -sL https://deb.nodesource.com/setup_19.x | sudo -E bash - && \
   sudo apt-get install nodejs build-essential && \
   sudo corepack enable && \
   # Install WP-CLI


### PR DESCRIPTION
## Description
This PR is a part of the changes needed for the update of wordpress JS packages and React.
[eslint-plugin-jest package is incompatible with Node 17](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/13465/workflows/989b206a-e31e-492f-a1f2-6420b03f1afa/jobs/229220) (needs 16 or 18 and above).

This PR fixes the issue for CircleCI by updating the Node version on the image we use in the image used for builds.

## Code review notes

_N/A_

## QA notes

_N/A_

## Linked PRs

_N/A_

## Linked tickets

[MAILPOET-5102]

## After-merge notes


[MAILPOET-5102]: https://mailpoet.atlassian.net/browse/MAILPOET-5102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ