### PR TITLE
Update PHP 7.3 image based on the PHP 7.2 image

### DIFF
--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -1,14 +1,14 @@
-FROM circleci/php:7.3-apache
+FROM cimg/php:7.3
 
 RUN sudo apt-get update && \
-  sudo apt-get install default-mysql-client zlib1g-dev libpng-dev libjpeg62-turbo-dev libfreetype6-dev && \
-  sudo docker-php-ext-configure gd --with-gd --with-png-dir --with-jpeg-dir --with-zlib-dir \
-    --with-freetype-dir && \
-  sudo docker-php-ext-install bcmath mysqli pdo pdo_mysql zip gd && \
+  sudo apt-get install default-mysql-client zlib1g-dev libpng-dev libfreetype6-dev && \
+  sudo apt-get install apache2 && \
+  sudo apt-get install postfix && \
   \
   # Install NodeJS + NPM
-  curl -sL https://deb.nodesource.com/setup_11.x | sudo -E bash - && \
+  curl -sL https://deb.nodesource.com/setup_18.x | sudo -E bash - && \
   sudo apt-get install nodejs build-essential && \
+  sudo corepack enable && \
   \
   # Install WP-CLI
   sudo curl -o /usr/local/bin/wp https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar && \
@@ -17,3 +17,8 @@ RUN sudo apt-get update && \
   # Clean up
   sudo apt-get clean && \
   sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN sudo mkdir -p /etc/php.d && \
+  echo 'memory_limit = -1' | sudo tee -a /etc/php.d/circleci.ini && \
+  sudo pear config-set php_ini /etc/php.d/circleci.ini && \
+  sudo pecl update-channels


### PR DESCRIPTION
This PR updates the Dockerfile for the PHP 7.3 based on the PHP 7.2 Dockerfile. The previous PHP 7.2 Docker images that were build based on the old config file are not working anymore and generated errors on CircleCI when we tried to use them in https://github.com/mailpoet/mailpoet/pull/4934.

[MAILPOET-4939]

[MAILPOET-4939]: https://mailpoet.atlassian.net/browse/MAILPOET-4939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ