### PR TITLE
Add configuration file for PHP 8.2 images

### DIFF
--- a/8.2-cli/Dockerfile
+++ b/8.2-cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2.0RC6-cli
+FROM php:8.2-cli
 
 RUN apt-get update && \
     apt-get -y install \
@@ -26,6 +26,6 @@ RUN apt-get update && \
     chmod +x wp-cli.phar && \
     mv wp-cli.phar /usr/local/bin/wp && \
     printf "account default\nhost smtp\nport 1025" > /etc/msmtprc && \
-    git clone -b "3.2.0RC2" --depth 1 https://github.com/xdebug/xdebug.git /usr/src/php/ext/xdebug \
+    git clone -b "3.2.2" --depth 1 https://github.com/xdebug/xdebug.git /usr/src/php/ext/xdebug \
     && docker-php-ext-configure xdebug --enable-xdebug-dev \
     && docker-php-ext-install xdebug

--- a/8.2/Dockerfile
+++ b/8.2/Dockerfile
@@ -3,7 +3,7 @@ FROM cimg/php:8.2
 RUN sudo add-apt-repository ppa:ondrej/php -y && \
   sudo apt-get update && \
   sudo apt-get install default-mysql-client zlib1g-dev libpng-dev libfreetype6-dev && \
-  sudo apt-get install libapache2-mod-php8.1 php-mysql apache2 && \
+  sudo apt-get install libapache2-mod-php8.2 php-mysql apache2 && \
   sudo pecl install xdebug &&\
   \
   # Install NodeJS, enable Corepack

--- a/8.2/Dockerfile
+++ b/8.2/Dockerfile
@@ -1,0 +1,19 @@
+FROM cimg/php:8.2
+
+RUN sudo add-apt-repository ppa:ondrej/php -y && \
+  sudo apt-get update && \
+  sudo apt-get install default-mysql-client zlib1g-dev libpng-dev libfreetype6-dev && \
+  sudo apt-get install libapache2-mod-php8.1 php-mysql apache2 && \
+  sudo pecl install xdebug &&\
+  \
+  # Install NodeJS, enable Corepack
+  curl -sL https://deb.nodesource.com/setup_19.x | sudo -E bash - && \
+  sudo apt-get install nodejs build-essential && \
+  sudo corepack enable && \
+  # Install WP-CLI
+  sudo curl -o /usr/local/bin/wp https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar && \
+  sudo chmod +x /usr/local/bin/wp && \
+  \
+  # Clean up
+  sudo apt-get clean && \
+  sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \


### PR DESCRIPTION
I'm assuming there is no reason to keep the 8.2 RC6 configuration files as it was just a temporary solution, and that is why I opted to rename it to 8.2 instead of creating a new folder and keeping the 8.2 RC6 one.

Here are the published images:

https://hub.docker.com/layers/mailpoet/wordpress/8.2_20231016.1/images/sha256-07e1142cda715999365ce80789d4c75a50b87e59ea50de86aae7bfa40e16b5a2?context=explore
https://hub.docker.com/layers/mailpoet/wordpress/8.2-cli_20231016.1/images/sha256-d0573fe21c81e092adfbb136540942f2fddfa5b53e14536dede289d7db973f97?context=explore

[MAILPOET-4620]

[MAILPOET-4620]: https://mailpoet.atlassian.net/browse/MAILPOET-4620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ