### PR TITLE
Update the PHP 7.4 Docker image [MAILPOET-5726]

### DIFF
--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -1,12 +1,12 @@
-FROM circleci/php:7.4-apache
+FROM cimg/php:7.4
 
 RUN sudo apt-get update && \
-  sudo apt-get install default-mysql-client zlib1g-dev libpng-dev libjpeg62-turbo-dev libfreetype6-dev && \
-  sudo docker-php-ext-configure gd --with-jpeg --with-freetype && \
-  sudo docker-php-ext-install bcmath mysqli pdo pdo_mysql zip gd && \
+  sudo apt-get install default-mysql-client zlib1g-dev libpng-dev libfreetype6-dev && \
+  sudo apt-get install apache2 && \
+  sudo apt-get install postfix && \
   \
   # Install NodeJS, enable Corepack
-  curl -sL https://deb.nodesource.com/setup_17.x | sudo -E bash - && \
+  curl -sL https://deb.nodesource.com/setup_18.x | sudo -E bash - && \
   sudo apt-get install nodejs build-essential && \
   sudo corepack enable && \
   \
@@ -17,3 +17,8 @@ RUN sudo apt-get update && \
   # Clean up
   sudo apt-get clean && \
   sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN sudo mkdir -p /etc/php.d && \
+  echo 'memory_limit = -1' | sudo tee -a /etc/php.d/circleci.ini && \
+  sudo pear config-set php_ini /etc/php.d/circleci.ini && \
+  sudo pecl update-channels


### PR DESCRIPTION
## Description

_N/A_

## Code review notes

Because CircleCI started using different images, we needed to update the image with PHP 7.4.

## QA notes

_N/A_

## Linked PRs

https://github.com/mailpoet/mailpoet/pull/5318
https://github.com/mailpoet/mailpoet-premium/pull/826

## Linked tickets

[MAILPOET-5726]

## After-merge notes

_N/A_



[MAILPOET-5726]: https://mailpoet.atlassian.net/browse/MAILPOET-5726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ