### PR TITLE
Add Docker images for WordPress 6.5

### DIFF
--- a/wp-6.5/php8.1/Dockerfile
+++ b/wp-6.5/php8.1/Dockerfile
@@ -1,0 +1,7 @@
+FROM wordpress:6.5.0-php8.1
+
+RUN docker-php-ext-install pdo_mysql && \
+    echo "date.timezone = UTC" >> /usr/local/etc/php/php.ini && \
+    \
+    # allow .htaccess files (between <Directory /var/www/> and </Directory>, which is WordPress installation)
+    sed -i '/<Directory \/var\/www\/>/,/<\/Directory>/ s/AllowOverride None/AllowOverride All/' /etc/apache2/apache2.conf

--- a/wp-6.5/php8.2/Dockerfile
+++ b/wp-6.5/php8.2/Dockerfile
@@ -1,0 +1,7 @@
+FROM wordpress:6.5.0-php8.2
+
+RUN docker-php-ext-install pdo_mysql && \
+    echo "date.timezone = UTC" >> /usr/local/etc/php/php.ini && \
+    \
+    # allow .htaccess files (between <Directory /var/www/> and </Directory>, which is WordPress installation)
+    sed -i '/<Directory \/var\/www\/>/,/<\/Directory>/ s/AllowOverride None/AllowOverride All/' /etc/apache2/apache2.conf

--- a/wp-6.5/php8.3/Dockerfile
+++ b/wp-6.5/php8.3/Dockerfile
@@ -1,0 +1,7 @@
+FROM wordpress:6.5.0-php8.3
+
+RUN docker-php-ext-install pdo_mysql && \
+    echo "date.timezone = UTC" >> /usr/local/etc/php/php.ini && \
+    \
+    # allow .htaccess files (between <Directory /var/www/> and </Directory>, which is WordPress installation)
+    sed -i '/<Directory \/var\/www\/>/,/<\/Directory>/ s/AllowOverride None/AllowOverride All/' /etc/apache2/apache2.conf


### PR DESCRIPTION
All pushed to Docker Hub: https://hub.docker.com/repository/docker/mailpoet/wordpress/tags?page=&page_size=&ordering=&name=6.5

Official WP image for PHP 8.0 is not available.

[MAILPOET-6003]

[MAILPOET-6003]: https://mailpoet.atlassian.net/browse/MAILPOET-6003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ