### PR TITLE
Update PHP 7.4-8.4 images from Node.js 19 to 22

### DIFF
--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -6,7 +6,7 @@ RUN sudo apt-get update && \
   sudo apt-get install postfix && \
   \
   # Install NodeJS, enable Corepack
-  curl -sL https://deb.nodesource.com/setup_18.x | sudo -E bash - && \
+  curl -sL https://deb.nodesource.com/setup_22.x | sudo -E bash - && \
   sudo apt-get install nodejs build-essential && \
   sudo corepack enable && \
   \

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -6,7 +6,7 @@ RUN sudo apt-get update && \
   sudo docker-php-ext-install bcmath mysqli pdo pdo_mysql zip gd && \
   \
   # Install NodeJS + NPM
-  curl -sL https://deb.nodesource.com/setup_16.x | sudo -E bash - && \
+  curl -sL https://deb.nodesource.com/setup_22.x | sudo -E bash - && \
   sudo apt-get install nodejs build-essential && \
   \
   # Install WP-CLI

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -7,7 +7,7 @@ RUN sudo add-apt-repository ppa:ondrej/php -y && \
   sudo pecl install xdebug &&\
   \
   # Install NodeJS, enable Corepack
-  curl -sL https://deb.nodesource.com/setup_19.x | sudo -E bash - && \
+  curl -sL https://deb.nodesource.com/setup_22.x | sudo -E bash - && \
   sudo apt-get install nodejs build-essential && \
   sudo corepack enable && \
   # Install WP-CLI

--- a/8.2/Dockerfile
+++ b/8.2/Dockerfile
@@ -7,7 +7,7 @@ RUN sudo add-apt-repository ppa:ondrej/php -y && \
   sudo pecl install xdebug &&\
   \
   # Install NodeJS, enable Corepack
-  curl -sL https://deb.nodesource.com/setup_19.x | sudo -E bash - && \
+  curl -sL https://deb.nodesource.com/setup_22.x | sudo -E bash - && \
   sudo apt-get install nodejs build-essential && \
   sudo corepack enable && \
   # Install WP-CLI

--- a/8.3/Dockerfile
+++ b/8.3/Dockerfile
@@ -7,7 +7,7 @@ RUN sudo add-apt-repository ppa:ondrej/php -y && \
   sudo pecl install xdebug &&\
   \
   # Install NodeJS, enable Corepack
-  curl -sL https://deb.nodesource.com/setup_19.x | sudo -E bash - && \
+  curl -sL https://deb.nodesource.com/setup_22.x | sudo -E bash - && \
   sudo apt-get install nodejs build-essential && \
   sudo corepack enable && \
   # Install WP-CLI

--- a/8.4/Dockerfile
+++ b/8.4/Dockerfile
@@ -7,7 +7,7 @@ RUN sudo add-apt-repository ppa:ondrej/php -y && \
   sudo pecl install xdebug &&\
   \
   # Install NodeJS, enable Corepack
-  curl -sL https://deb.nodesource.com/setup_19.x | sudo -E bash - && \
+  curl -sL https://deb.nodesource.com/setup_22.x | sudo -E bash - && \
   sudo apt-get install nodejs build-essential && \
   sudo corepack enable && \
   # Install WP-CLI


### PR DESCRIPTION
All images are published to Docker Hub
- `mailpoet/wordpress:7.4_20250815.1`
- `mailpoet/wordpress:8.0_20250815.1`
- `mailpoet/wordpress:8.1_20250815.1`
- `mailpoet/wordpress:8.2_20250815.1`
- `mailpoet/wordpress:8.3_20250815.1`
- `mailpoet/wordpress:8.4_20250815.1`

Passing builds:
- [Free](https://app.circleci.com/pipelines/github/mailpoet/mailpoet/21219/workflows/a5b94f1f-01bc-4420-a2e0-8ff9c7ef9941)
- [Premium](https://app.circleci.com/pipelines/github/mailpoet/mailpoet-premium/4045/workflows/a7155fd7-66f3-4263-a14c-85465d05f8c1)

STOMAIL-7522